### PR TITLE
Fixed a typo, player must input proper input to continue game

### DIFF
--- a/pig.py
+++ b/pig.py
@@ -27,6 +27,8 @@ while not done:
             player_temp_total += roll
             print("You currently have " + str(player_temp_total) + " banked.")
             choice = input("Do you wish to roll again (y/n)?: ")
+            while(choice != 'n' and choice != 'y') :
+                choice = input("Do you wish to roll again (y/n)?: ")
             if choice == 'n':
                 player_total += player_temp_total
                 player_temp_total = 0

--- a/pig.py
+++ b/pig.py
@@ -32,7 +32,7 @@ while not done:
             if choice == 'n':
                 player_total += player_temp_total
                 player_temp_total = 0
-                print("Your total socre is now:", player_total)
+                print("Your total score is now:", player_total)
                 turn = "computer"
         if player_total > winning_score:
             print("You win! " + str(player_total) + " to " + str(comp_total))


### PR DESCRIPTION
In pig.py, the word 'score' was misspelled. This has been corrected.

Also in pig.py, in order to continue playing the game, the player must selected 'y' or 'n' rather than 'n' or any other input.